### PR TITLE
feat: Implement responsive layout for content area

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     />
 
     <title>Stitch Design</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" type="image/x-icon" href="data:image/x-icon;base64," />
 
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
@@ -43,152 +44,158 @@
             </button>
           </div>
         </div>
-        <h1 class="text-white text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 text-center pb-3 pt-5">nCode</h1>
-        <p class="text-white text-base font-normal leading-normal pb-3 pt-1 px-4 text-center">Encrypt and decrypt strings with ease.</p>
-        <div class="pb-3">
-          <div class="flex border-b border-[#43543b] px-4 gap-8">
-            <a class="flex flex-col items-center justify-center border-b-[3px] border-b-white text-white pb-[13px] pt-4" href="javascript:void(0);" onclick="showContent('stringEncryptionContent', this)">
-              <p class="text-white text-sm font-bold leading-normal tracking-[0.015em]">String Encryption</p>
-            </a>
-            <a class="flex flex-col items-center justify-center border-b-[3px] border-b-transparent text-[#a6ba9c] pb-[13px] pt-4" href="javascript:void(0);" onclick="showContent('passwordManagerContent', this)">
-              <p class="text-[#a6ba9c] text-sm font-bold leading-normal tracking-[0.015em]">Password Manager</p>
-            </a>
-            <a class="flex flex-col items-center justify-center border-b-[3px] border-b-transparent text-[#a6ba9c] pb-[13px] pt-4" href="javascript:void(0);" onclick="showContent('fileEncryptionContent', this)">
-              <p class="text-[#a6ba9c] text-sm font-bold leading-normal tracking-[0.015em]">File Encryption</p>
-            </a>
-          </div>
-        </div>
-        <div id="stringEncryptionContent">
-          <p class="text-white text-base font-normal leading-normal pb-3 pt-1 px-4">Use this tool to encrypt or decrypt text strings using a password. Ensure you remember your password, as it's the only way to retrieve your original data.</p>
-          <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-            <label class="flex flex-col min-w-40 flex-1">
-              <textarea
-                id="stringInput"
-                placeholder="String"
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded text-white focus:outline-0 focus:ring-0 border border-[#43543b] bg-[#1f271b] focus:border-[#43543b] min-h-36 placeholder:text-[#a6ba9c] p-[15px] text-base font-normal leading-normal"
-              style="overflow: auto"></textarea>
-            </label>
-          </div>
-          <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-            <label class="flex flex-col min-w-40 flex-1">
-              <input
-                id="passwordInput"
-                placeholder="Password"
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded text-white focus:outline-0 focus:ring-0 border border-[#43543b] bg-[#1f271b] focus:border-[#43543b] h-14 placeholder:text-[#a6ba9c] p-[15px] text-base font-normal leading-normal"
-                value=""
-              />
-            </label>
-          </div>
-          <div class="flex items-center gap-4 px-4 py-3">
-            <span class="text-white">nCode</span>
-            <label class="relative inline-flex items-center cursor-pointer">
-              <input type="checkbox" id="modeToggle" class="sr-only peer">
-              <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-green-300 dark:peer-focus:ring-green-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-green-600"></div>
-            </label>
-            <span class="text-white">dCode</span>
-          </div>
-          <div class="flex px-4 py-3">
-            <button
-              id="processButton"
-              class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded h-10 px-4 bg-[#47c10a] text-[#131811] text-sm font-bold leading-normal tracking-[0.015em]"
-            >
-              <span class="truncate">Process</span>
-            </button>
-          </div>
-          <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-            <label class="flex flex-col min-w-40 flex-1">
-              <textarea
-                id="resultOutput"
-                placeholder="Result"
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded text-white focus:outline-0 focus:ring-0 border border-[#43543b] bg-[#1f271b] focus:border-[#43543b] min-h-36 placeholder:text-[#a6ba9c] p-[15px] text-base font-normal leading-normal"
-              style="overflow: auto"></textarea>
-            </label>
-          </div>
-          <div class="flex px-4 py-3">
-            <button id="clearButton" class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded h-10 px-4 bg-[#f0ad4e] text-[#131811] text-sm font-bold leading-normal tracking-[0.015em] mr-2"><span class="truncate">Clear</span></button>
-            <button id="copyButton" class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded h-10 px-4 bg-[#5bc0de] text-[#131811] text-sm font-bold leading-normal tracking-[0.015em]"><span class="truncate">Copy</span></button>
-          </div>
-        </div>
-        <div id="passwordManagerContent" style="display:none;">
-          <p class="text-white text-base font-normal leading-normal pb-3 pt-1 px-4">
-            Manage your passwords securely with nCode's Password Manager. Encrypt and decrypt your passwords for enhanced security.
-          </p>
-          <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-            <label class="flex flex-col min-w-40 flex-1">
-              <input
-                placeholder="Manager Password"
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-white focus:outline-0 focus:ring-0 border border-[#464d42] bg-[#20241e] focus:border-[#464d42] h-14 placeholder:text-[#a9b2a4] p-[15px] text-base font-normal leading-normal"
-                value=""
-              />
-            </label>
-          </div>
-          <h3 class="text-white text-lg font-bold leading-tight tracking-[-0.015em] px-4 pb-2 pt-4">Sites</h3>
-          <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-            <label class="flex flex-col min-w-40 flex-1">
-              <input
-                placeholder="Site 1"
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-white focus:outline-0 focus:ring-0 border border-[#464d42] bg-[#20241e] focus:border-[#464d42] h-14 placeholder:text-[#a9b2a4] p-[15px] text-base font-normal leading-normal"
-                value=""
-              />
-            </label>
-          </div>
-          <div class="flex items-center gap-4 bg-[#141613] px-4 min-h-14">
-            <div class="text-white flex items-center justify-center rounded-lg bg-[#2f342d] shrink-0 size-10" data-icon="Plus" data-size="24px" data-weight="regular">
-              <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
-                <path d="M224,128a8,8,0,0,1-8,8H136v80a8,8,0,0,1-16,0V136H40a8,8,0,0,1,0-16h80V40a8,8,0,0,1,16,0v80h80A8,8,0,0,1,224,128Z"></path>
-              </svg>
+        <!-- New Outer Wrapper Div -->
+        <div class="w-full">
+          <!-- New Middle Column Div -->
+          <div class="w-full md:w-1/3 mx-auto">
+            <h1 class="text-white text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 text-center pb-3 pt-5">nCode</h1>
+            <p class="text-white text-base font-normal leading-normal pb-3 pt-1 px-4 text-center">Encrypt and decrypt strings with ease.</p>
+            <div class="pb-3">
+              <div class="flex border-b border-[#43543b] px-4 gap-8">
+                <a class="flex flex-col items-center justify-center border-b-[3px] border-b-white text-white pb-[13px] pt-4" href="javascript:void(0);" onclick="showContent('stringEncryptionContent', this)">
+                  <p class="text-white text-sm font-bold leading-normal tracking-[0.015em]">String Encryption</p>
+                </a>
+                <a class="flex flex-col items-center justify-center border-b-[3px] border-b-transparent text-[#a6ba9c] pb-[13px] pt-4" href="javascript:void(0);" onclick="showContent('passwordManagerContent', this)">
+                  <p class="text-[#a6ba9c] text-sm font-bold leading-normal tracking-[0.015em]">Password Manager</p>
+                </a>
+                <a class="flex flex-col items-center justify-center border-b-[3px] border-b-transparent text-[#a6ba9c] pb-[13px] pt-4" href="javascript:void(0);" onclick="showContent('fileEncryptionContent', this)">
+                  <p class="text-[#a6ba9c] text-sm font-bold leading-normal tracking-[0.015em]">File Encryption</p>
+                </a>
+              </div>
             </div>
-            <p class="text-white text-base font-normal leading-normal flex-1 truncate">Add Site</p>
-          </div>
-          <div class="flex px-4 py-3 justify-end">
-            <button
-              class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded h-10 px-4 bg-[#47c10a] text-[#131811] text-sm font-bold leading-normal tracking-[0.015em]"
-            >
-              <span class="truncate">Process</span>
-            </button>
-          </div>
-          <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-            <label class="flex flex-col min-w-40 flex-1">
-              <textarea
-                placeholder="Result"
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded text-white focus:outline-0 focus:ring-0 border border-[#43543b] bg-[#1f271b] focus:border-[#43543b] min-h-36 placeholder:text-[#a6ba9c] p-[15px] text-base font-normal leading-normal"
-              ></textarea>
-            </label>
-          </div>
-        </div>
-        <div id="fileEncryptionContent" style="display:none;">
-          <p class="text-white text-base font-normal leading-normal pb-3 pt-1 px-4">Encrypt your files with a password to protect them from unauthorized access.</p>
-          <div class="flex px-4 py-3">
-            <button
-              class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-10 px-4 flex-1 bg-[#2e3928] text-white text-sm font-bold leading-normal tracking-[0.015em]"
-            >
-              <span class="truncate">Upload File</span>
-            </button>
-          </div>
-          <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-            <label class="flex flex-col min-w-40 flex-1">
-              <input
-                placeholder="Password"
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-white focus:outline-0 focus:ring-0 border border-[#44543b] bg-[#1f271b] focus:border-[#44543b] h-14 placeholder:text-[#a6ba9c] p-[15px] text-base font-normal leading-normal"
-                value=""
-              />
-            </label>
-          </div>
-          <div class="flex px-4 py-3 justify-end">
-            <button
-              class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded h-10 px-4 bg-[#47c10a] text-[#131811] text-sm font-bold leading-normal tracking-[0.015em]"
-            >
-              <span class="truncate">Process</span>
-            </button>
-          </div>
-          <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-            <label class="flex flex-col min-w-40 flex-1">
-              <p class="text-white text-base font-medium leading-normal pb-2">Result</p>
-              <textarea
-                placeholder="Result"
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded text-white focus:outline-0 focus:ring-0 border border-[#43543b] bg-[#1f271b] focus:border-[#43543b] min-h-36 placeholder:text-[#a6ba9c] p-[15px] text-base font-normal leading-normal"
-              ></textarea>
-            </label>
+            <div id="stringEncryptionContent">
+              <p class="text-white text-base font-normal leading-normal pb-3 pt-1 px-4">Use this tool to encrypt or decrypt text strings using a password. Ensure you remember your password, as it's the only way to retrieve your original data.</p>
+              <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
+                <label class="flex flex-col min-w-40 flex-1">
+                  <textarea
+                    id="stringInput"
+                    placeholder="String"
+                    class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded text-white focus:outline-0 focus:ring-0 border border-[#43543b] bg-[#1f271b] focus:border-[#43543b] min-h-36 placeholder:text-[#a6ba9c] p-[15px] text-base font-normal leading-normal"
+                  style="overflow: auto"></textarea>
+                </label>
+              </div>
+              <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
+                <label class="flex flex-col min-w-40 flex-1">
+                  <input
+                    id="passwordInput"
+                    placeholder="Password"
+                    class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded text-white focus:outline-0 focus:ring-0 border border-[#43543b] bg-[#1f271b] focus:border-[#43543b] h-14 placeholder:text-[#a6ba9c] p-[15px] text-base font-normal leading-normal"
+                    value=""
+                  />
+                </label>
+              </div>
+              <div class="flex items-center gap-4 px-4 py-3">
+                <span class="text-white">nCode</span>
+                <label class="relative inline-flex items-center cursor-pointer">
+                  <input type="checkbox" id="modeToggle" class="sr-only peer">
+                  <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-green-300 dark:peer-focus:ring-green-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-green-600"></div>
+                </label>
+                <span class="text-white">dCode</span>
+              </div>
+              <div class="flex px-4 py-3">
+                <button
+                  id="processButton"
+                  class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded h-10 px-4 bg-[#47c10a] text-[#131811] text-sm font-bold leading-normal tracking-[0.015em]"
+                >
+                  <span class="truncate">Process</span>
+                </button>
+              </div>
+              <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
+                <label class="flex flex-col min-w-40 flex-1">
+                  <textarea
+                    id="resultOutput"
+                    placeholder="Result"
+                    class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded text-white focus:outline-0 focus:ring-0 border border-[#43543b] bg-[#1f271b] focus:border-[#43543b] min-h-36 placeholder:text-[#a6ba9c] p-[15px] text-base font-normal leading-normal"
+                  style="overflow: auto"></textarea>
+                </label>
+              </div>
+              <div class="flex px-4 py-3">
+                <button id="clearButton" class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded h-10 px-4 bg-[#f0ad4e] text-[#131811] text-sm font-bold leading-normal tracking-[0.015em] mr-2"><span class="truncate">Clear</span></button>
+                <button id="copyButton" class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded h-10 px-4 bg-[#5bc0de] text-[#131811] text-sm font-bold leading-normal tracking-[0.015em]"><span class="truncate">Copy</span></button>
+              </div>
+            </div>
+            <div id="passwordManagerContent" style="display:none;">
+              <p class="text-white text-base font-normal leading-normal pb-3 pt-1 px-4">
+                Manage your passwords securely with nCode's Password Manager. Encrypt and decrypt your passwords for enhanced security.
+              </p>
+              <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
+                <label class="flex flex-col min-w-40 flex-1">
+                  <input
+                    placeholder="Manager Password"
+                    class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-white focus:outline-0 focus:ring-0 border border-[#464d42] bg-[#20241e] focus:border-[#464d42] h-14 placeholder:text-[#a9b2a4] p-[15px] text-base font-normal leading-normal"
+                    value=""
+                  />
+                </label>
+              </div>
+              <h3 class="text-white text-lg font-bold leading-tight tracking-[-0.015em] px-4 pb-2 pt-4">Sites</h3>
+              <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
+                <label class="flex flex-col min-w-40 flex-1">
+                  <input
+                    placeholder="Site 1"
+                    class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-white focus:outline-0 focus:ring-0 border border-[#464d42] bg-[#20241e] focus:border-[#464d42] h-14 placeholder:text-[#a9b2a4] p-[15px] text-base font-normal leading-normal"
+                    value=""
+                  />
+                </label>
+              </div>
+              <div class="flex items-center gap-4 bg-[#141613] px-4 min-h-14">
+                <div class="text-white flex items-center justify-center rounded-lg bg-[#2f342d] shrink-0 size-10" data-icon="Plus" data-size="24px" data-weight="regular">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                    <path d="M224,128a8,8,0,0,1-8,8H136v80a8,8,0,0,1-16,0V136H40a8,8,0,0,1,0-16h80V40a8,8,0,0,1,16,0v80h80A8,8,0,0,1,224,128Z"></path>
+                  </svg>
+                </div>
+                <p class="text-white text-base font-normal leading-normal flex-1 truncate">Add Site</p>
+              </div>
+              <div class="flex px-4 py-3 justify-end">
+                <button
+                  class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded h-10 px-4 bg-[#47c10a] text-[#131811] text-sm font-bold leading-normal tracking-[0.015em]"
+                >
+                  <span class="truncate">Process</span>
+                </button>
+              </div>
+              <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
+                <label class="flex flex-col min-w-40 flex-1">
+                  <textarea
+                    placeholder="Result"
+                    class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded text-white focus:outline-0 focus:ring-0 border border-[#43543b] bg-[#1f271b] focus:border-[#43543b] min-h-36 placeholder:text-[#a6ba9c] p-[15px] text-base font-normal leading-normal"
+                  ></textarea>
+                </label>
+              </div>
+            </div>
+            <div id="fileEncryptionContent" style="display:none;">
+              <p class="text-white text-base font-normal leading-normal pb-3 pt-1 px-4">Encrypt your files with a password to protect them from unauthorized access.</p>
+              <div class="flex px-4 py-3">
+                <button
+                  class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-10 px-4 flex-1 bg-[#2e3928] text-white text-sm font-bold leading-normal tracking-[0.015em]"
+                >
+                  <span class="truncate">Upload File</span>
+                </button>
+              </div>
+              <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
+                <label class="flex flex-col min-w-40 flex-1">
+                  <input
+                    placeholder="Password"
+                    class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-white focus:outline-0 focus:ring-0 border border-[#44543b] bg-[#1f271b] focus:border-[#44543b] h-14 placeholder:text-[#a6ba9c] p-[15px] text-base font-normal leading-normal"
+                    value=""
+                  />
+                </label>
+              </div>
+              <div class="flex px-4 py-3 justify-end">
+                <button
+                  class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded h-10 px-4 bg-[#47c10a] text-[#131811] text-sm font-bold leading-normal tracking-[0.015em]"
+                >
+                  <span class="truncate">Process</span>
+                </button>
+              </div>
+              <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
+                <label class="flex flex-col min-w-40 flex-1">
+                  <p class="text-white text-base font-medium leading-normal pb-2">Result</p>
+                  <textarea
+                    placeholder="Result"
+                    class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded text-white focus:outline-0 focus:ring-0 border border-[#43543b] bg-[#1f271b] focus:border-[#43543b] min-h-36 placeholder:text-[#a6ba9c] p-[15px] text-base font-normal leading-normal"
+                  ></textarea>
+                </label>
+              </div>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This commit introduces changes to make the main content area responsive:

- On desktop screens, the content below the navigation bar is now displayed in the middle third of the screen, with elements inside this column left-justified.
- On mobile screens, the content utilizes the full width of the screen for better readability and user experience.

Changes include:
- Added a viewport meta tag for proper mobile scaling.
- Restructured the HTML by wrapping the main content in new divs.
- Applied Tailwind CSS classes to control the width and centering of the content column based on screen size.