### PR TITLE
Refactor: Update Transmission Tab UI and Functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,10 +260,13 @@
                   <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-green-300 dark:peer-focus:ring-green-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-green-600"></div>
                 </label>
                 <span class="text-white">dCode</span>
+                <button id="clearKeysButton" class="flex min-w-[84px] cursor-pointer items-center justify-center overflow-hidden rounded h-10 px-4 bg-[#f0ad4e] text-[#131811] text-sm font-bold leading-normal tracking-[0.015em] ml-3">
+                  <span class="truncate">Clear</span>
+                </button>
               </div>
 
               <!-- Key Pair Management Section -->
-              <div class="border-t border-[#43543b] mt-4 pt-4">
+              <div id="key-pair-management-section" class="border-t border-[#43543b] mt-4 pt-4">
                 <h3 class="text-white text-lg font-bold leading-tight tracking-[-0.015em] px-4 pb-2">Your Key Pair Management</h3>
 
                 <div class="flex px-4 py-3">
@@ -284,10 +287,7 @@
                   <button id="generateAndDownloadKeysButton" class="flex min-w-[84px] cursor-pointer items-center justify-center overflow-hidden rounded h-10 px-4 bg-[#47c10a] text-[#131811] text-sm font-bold leading-normal tracking-[0.015em] flex-1">
                     <span class="truncate">Generate & Encrypt Keys</span>
                   </button>
-                  <!-- This button might be redundant if the above handles download, or might be enabled later. Keeping for now. -->
-                  <button id="download-key-pair-button" class="flex min-w-[84px] cursor-pointer items-center justify-center overflow-hidden rounded h-10 px-4 bg-[#5bc0de] text-[#131811] text-sm font-bold leading-normal tracking-[0.015em] flex-1">
-                    <span class="truncate">Download Encrypted Key Pair (.nCodeKeys)</span>
-                  </button>
+                  <!-- Redundant button "download-key-pair-button" removed -->
                 </div>
 
                 <div class="border-t border-[#43543b] mt-4 pt-4"></div>
@@ -330,9 +330,8 @@
                     <span class="truncate">Copy Public Key</span>
                   </button>
                   <!-- ID changed -->
-                  <button id="clearKeysButton" class="flex min-w-[84px] cursor-pointer items-center justify-center overflow-hidden rounded h-10 px-4 bg-[#f0ad4e] text-[#131811] text-sm font-bold leading-normal tracking-[0.015em] flex-1">
-                    <span class="truncate">Clear Loaded Keys</span>
                   </button>
+                  <!-- The clearKeysButton was moved up -->
                 </div>
               </div>
               <!-- End of Key Pair Management Section -->

--- a/scripts/transmission.js
+++ b/scripts/transmission.js
@@ -642,42 +642,49 @@ async function loadEncryptedKeys() {
 }
 
 function clearLoadedKeys() {
-    const publicKeyDisplayArea = document.getElementById('public-key-display-area');
-    const copyPublicKeyButton = document.getElementById('copyPublicKeyButton');
-    const keyGenPassphraseInput = document.getElementById('keyGenPassphraseInput');
-    const keyLoadPassphraseInput = document.getElementById('keyLoadPassphraseInput');
-    const uploadEncryptedKeysInput = document.getElementById('uploadEncryptedKeysInput'); // Assuming this is the ID of the file input for uploading keys
-
     // Reset global variables
     currentKeyPair = null;
     uploadedKeyFileData = null;
 
     // Clear UI Elements
-    if (publicKeyDisplayArea) {
-        publicKeyDisplayArea.value = "";
-    }
-    if (keyGenPassphraseInput) {
-        keyGenPassphraseInput.value = "";
-    }
-    if (keyLoadPassphraseInput) {
-        keyLoadPassphraseInput.value = "";
-    }
+    // Key Management Section related
+    const keyGenPassphraseInput = document.getElementById('keyGenPassphraseInput');
+    if (keyGenPassphraseInput) keyGenPassphraseInput.value = "";
 
-    // Disable Buttons
-    if (copyPublicKeyButton) {
-        copyPublicKeyButton.disabled = true;
-    }
+    const keyLoadPassphraseInput = document.getElementById('keyLoadPassphraseInput');
+    if (keyLoadPassphraseInput) keyLoadPassphraseInput.value = "";
 
-    // Clear File Input
-    if (uploadEncryptedKeysInput) {
-        uploadEncryptedKeysInput.value = null; // This effectively clears the selected file
-    }
+    const uploadEncryptedKeysInput = document.getElementById('uploadEncryptedKeysInput');
+    if (uploadEncryptedKeysInput) uploadEncryptedKeysInput.value = null; // Clears file selection
 
-    // User Feedback (Optional but good)
-    // Consider if an alert is too intrusive for a clear action.
-    // A more subtle notification might be better, or none if the UI changes are obvious.
-    // For now, per plan:
-    alert("Loaded keys and related data have been cleared.");
+    const publicKeyDisplayArea = document.getElementById('public-key-display-area');
+    if (publicKeyDisplayArea) publicKeyDisplayArea.value = "";
+
+    const copyPublicKeyButton = document.getElementById('copyPublicKeyButton');
+    if (copyPublicKeyButton) copyPublicKeyButton.disabled = true; // Also disable copy button
+
+    // nCode Workflow Section related
+    const recipientPublicKeyInput = document.getElementById('recipientPublicKeyInput');
+    if (recipientPublicKeyInput) recipientPublicKeyInput.value = "";
+
+    const ncodeFileInput = document.getElementById('ncodeFileInput');
+    if (ncodeFileInput) ncodeFileInput.value = null; // Clears file selection
+
+    const ncodeStringInput = document.getElementById('ncodeStringInput');
+    if (ncodeStringInput) ncodeStringInput.value = "";
+
+    // dCode Workflow Section related
+    const dcodeFileInput = document.getElementById('dcodeFileInput');
+    if (dcodeFileInput) dcodeFileInput.value = null; // Clears file selection
+
+    const dcodeStringOutput = document.getElementById('dcodeStringOutput');
+    if (dcodeStringOutput) dcodeStringOutput.value = "";
+
+    const dcodeFilesOutput = document.getElementById('dcodeFilesOutput');
+    if (dcodeFilesOutput) dcodeFilesOutput.innerHTML = ""; // Clear any generated links or messages
+
+    // No alert needed as per new requirements.
+    // console.log("Loaded keys and related data have been cleared."); // Optional: for debugging
 }
 
 async function copyPublicKey() {
@@ -733,31 +740,30 @@ async function copyPublicKey() {
 
 
 document.addEventListener('DOMContentLoaded', function () {
-    // Mode toggle logic (existing)
+    // Mode toggle logic
     const modeToggle = document.getElementById('transmission-mode-toggle');
     const ncodeSection = document.getElementById('ncode-section');
     const dcodeSection = document.getElementById('dcode-section');
+    const keyPairManagementSection = document.getElementById('key-pair-management-section'); // Added
 
-    if (modeToggle && ncodeSection && dcodeSection) {
-        modeToggle.addEventListener('change', function() {
-            if (this.checked) { // DCode mode
+    if (modeToggle && ncodeSection && dcodeSection && keyPairManagementSection) { // Added keyPairManagementSection
+        function updateDisplayMode() {
+            if (modeToggle.checked) { // DCode mode selected
                 ncodeSection.style.display = 'none';
                 dcodeSection.style.display = 'block';
-            } else { // NCode mode
+                keyPairManagementSection.style.display = 'none'; // Hide key management
+            } else { // NCode mode selected
                 ncodeSection.style.display = 'block';
                 dcodeSection.style.display = 'none';
+                keyPairManagementSection.style.display = 'block'; // Show key management
             }
-        });
-        // Set initial state
-        if (modeToggle.checked) {
-            ncodeSection.style.display = 'none';
-            dcodeSection.style.display = 'block';
-        } else {
-            ncodeSection.style.display = 'block';
-            dcodeSection.style.display = 'none';
         }
+
+        modeToggle.addEventListener('change', updateDisplayMode);
+        // Set initial state
+        updateDisplayMode(); // Call the function to set initial state
     } else {
-        console.error('Transmission mode toggle elements not found!');
+        console.error('Transmission mode toggle elements or key pair management section not found!');
     }
 
     // Get DOM elements for nCode/dCode Key Management and Workflows


### PR DESCRIPTION
This commit implements several UI and UX improvements to the Transmission Encryption tab:

1.  **Clear Button:**
    *   The "Clear Loaded Keys" button is now simply "Clear".
    *   It has been moved to the top of the tab, next to the nCode/dCode toggle switch.
    *   Its functionality has been expanded to clear all input fields, text areas, and file selections across the entire Transmission tab.

2.  **Key Generation Section Visibility:**
    *   The "Key Pair Management" section (which includes key generation and loading) is now hidden when "dCode" mode is selected. It remains visible in "nCode" mode, as key generation is primarily relevant when preparing to encrypt.

3.  **Consolidated Key Download:**
    *   Removed the redundant "Download Encrypted Key Pair (.nCodeKeys)" button.
    *   The "Generate & Encrypt Keys" button remains the sole method for generating and downloading new key pairs, streamlining the UI.

These changes improve the usability and clarity of the Transmission Encryption tab.