### PR TITLE
Fix: Adjust Transmission Tab UI based on feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -269,25 +269,21 @@
               <div id="key-pair-management-section" class="border-t border-[#43543b] mt-4 pt-4">
                 <h3 class="text-white text-lg font-bold leading-tight tracking-[-0.015em] px-4 pb-2">Your Key Pair Management</h3>
 
-                <div class="flex px-4 py-3">
-                  <button id="generate-key-pair-button" class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded h-10 px-4 bg-[#2e3928] text-white text-sm font-bold leading-normal tracking-[0.015em] flex-1">
-                    <span class="truncate">Generate New Key Pair</span>
-                  </button>
-                </div>
+                <!-- This h3 replaces the generate-key-pair-button -->
+                <h3 class="text-white text-md font-bold leading-tight tracking-[-0.015em] px-4 py-3">Generate New Key Pair</h3>
 
-                <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-                  <label class="flex flex-col min-w-40 flex-1">
-                    <!-- ID changed -->
-                    <input type="password" id="keyGenPassphraseInput" placeholder="Passphrase for Key Protection (Optional)" class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded text-white focus:outline-0 focus:ring-0 border border-[#43543b] bg-[#1f271b] focus:border-[#43543b] h-14 placeholder:text-[#a6ba9c] p-[15px] text-base font-normal leading-normal"/>
-                  </label>
-                </div>
+                <div id="new-key-generation-elements">
+                  <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
+                    <label class="flex flex-col min-w-40 flex-1">
+                      <input type="password" id="keyGenPassphraseInput" placeholder="Passphrase for Key Protection (Optional)" class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded text-white focus:outline-0 focus:ring-0 border border-[#43543b] bg-[#1f271b] focus:border-[#43543b] h-14 placeholder:text-[#a6ba9c] p-[15px] text-base font-normal leading-normal"/>
+                    </label>
+                  </div>
 
-                <div class="flex px-4 py-3 gap-2">
-                  <!-- ID changed -->
-                  <button id="generateAndDownloadKeysButton" class="flex min-w-[84px] cursor-pointer items-center justify-center overflow-hidden rounded h-10 px-4 bg-[#47c10a] text-[#131811] text-sm font-bold leading-normal tracking-[0.015em] flex-1">
-                    <span class="truncate">Generate & Encrypt Keys</span>
-                  </button>
-                  <!-- Redundant button "download-key-pair-button" removed -->
+                  <div class="flex px-4 py-3 gap-2">
+                    <button id="generateAndDownloadKeysButton" class="flex min-w-[84px] cursor-pointer items-center justify-center overflow-hidden rounded h-10 px-4 bg-[#47c10a] text-[#131811] text-sm font-bold leading-normal tracking-[0.015em] flex-1">
+                      <span class="truncate">Generate & Encrypt Keys</span>
+                    </button>
+                  </div>
                 </div>
 
                 <div class="border-t border-[#43543b] mt-4 pt-4"></div>

--- a/scripts/transmission.js
+++ b/scripts/transmission.js
@@ -744,26 +744,29 @@ document.addEventListener('DOMContentLoaded', function () {
     const modeToggle = document.getElementById('transmission-mode-toggle');
     const ncodeSection = document.getElementById('ncode-section');
     const dcodeSection = document.getElementById('dcode-section');
-    const keyPairManagementSection = document.getElementById('key-pair-management-section'); // Added
+    const keyPairManagementSection = document.getElementById('key-pair-management-section');
+    const newKeyGenerationElements = document.getElementById('new-key-generation-elements'); // Added
 
-    if (modeToggle && ncodeSection && dcodeSection && keyPairManagementSection) { // Added keyPairManagementSection
+    if (modeToggle && ncodeSection && dcodeSection && keyPairManagementSection && newKeyGenerationElements) { // Added newKeyGenerationElements
         function updateDisplayMode() {
+            keyPairManagementSection.style.display = 'block'; // Ensure parent section is always visible
+
             if (modeToggle.checked) { // DCode mode selected
                 ncodeSection.style.display = 'none';
                 dcodeSection.style.display = 'block';
-                keyPairManagementSection.style.display = 'none'; // Hide key management
+                newKeyGenerationElements.style.display = 'none'; // Hide only key GEN specific elements
             } else { // NCode mode selected
                 ncodeSection.style.display = 'block';
                 dcodeSection.style.display = 'none';
-                keyPairManagementSection.style.display = 'block'; // Show key management
+                newKeyGenerationElements.style.display = 'block'; // Show key GEN specific elements
             }
         }
 
         modeToggle.addEventListener('change', updateDisplayMode);
         // Set initial state
-        updateDisplayMode(); // Call the function to set initial state
+        updateDisplayMode();
     } else {
-        console.error('Transmission mode toggle elements or key pair management section not found!');
+        console.error('One or more transmission mode toggle elements or sections not found! Check IDs: transmission-mode-toggle, ncode-section, dcode-section, key-pair-management-section, new-key-generation-elements');
     }
 
     // Get DOM elements for nCode/dCode Key Management and Workflows


### PR DESCRIPTION
This commit addresses your feedback on the Transmission Encryption tab changes:

1.  **Key Pair Loading Visibility:**
    *   The "Key Pair Management" section has been restructured.
    *   Elements for uploading and loading an existing key pair (upload button, passphrase input, load button, public key display) are now always visible in both nCode and dCode modes. This allows you to load your keys regardless of whether you are encrypting or decrypting.

2.  **Key Generation Elements Visibility:**
    *   Only the elements specifically for *generating a new key pair* (passphrase input for new key protection, "Generate & Encrypt Keys" button) are now hidden when "dCode" mode is selected. These remain visible in "nCode" mode.

3.  **Static Title for Key Generation:**
    *   The "Generate New Key Pair" button has been changed to a static `h3` title, as it served as a section header.

These changes refine the UI to better match your workflows, ensuring necessary key management options are available when needed, while keeping the interface clean. The "Clear" button functionality and placement, and nCode/dCode workflow section toggling, remain as per the previous update.