### PR TITLE
Fix: Ensure dynamically added site inputs are removed on clear

### DIFF
--- a/scripts/password-manager.js
+++ b/scripts/password-manager.js
@@ -63,7 +63,7 @@ $(document).ready(function() {
   $('#addSiteButton').on('click', function() {
     siteCounter++;
     const newSiteInputHtml = `
-      <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
+      <div class="site-input-wrapper flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
         <label class="flex flex-col min-w-40 flex-1">
           <input
             placeholder="Site ${siteCounter}"
@@ -140,13 +140,10 @@ $(document).ready(function() {
     //   <!-- Dynamically added sites follow the same wrapper structure -->
     // </div>
     // So, we target these direct child divs for removal.
-    const siteInputWrappers = sitesContainer.children('div.flex.max-w-\[480px\].flex-wrap.items-end.gap-4.px-4.py-3');
+    const siteInputWrappers = sitesContainer.children('.site-input-wrapper');
 
-    // Remove additional site input wrappers (all except the first one)
-    // The first one is cleared by the siteInputs.each() loop above and should not be removed.
-    if (siteInputWrappers.length > 1) {
-      siteInputWrappers.slice(1).remove();
-    }
+    // Remove all dynamically added site input wrappers.
+    siteInputWrappers.remove();
 
     // Reset siteCounter
     siteCounter = 1;


### PR DESCRIPTION
The "Clear" button in the Password Manager was not correctly removing dynamically added site input fields ("Site 2", "Site 3", etc.). It was only clearing their content.

This commit addresses the issue by:
1. Adding a dedicated CSS class `site-input-wrapper` to each dynamically generated site input's container div. This makes the JavaScript selector for these elements more robust and less dependent on specific Tailwind utility classes.
2. Modifying the clear button's JavaScript handler:
   - It now uses `sitesContainer.children('.site-input-wrapper')` to select all dynamically added site input wrappers.
   - It then calls `.remove()` on this collection to delete all these dynamic inputs, leaving the original "Site 1" input intact.
   - The "Site 1" input, along with other fields like "Manager Password" and "Result Output", continues to be cleared of its content.
   - The `siteCounter` is correctly reset to 1.

This ensures that the UI behaves as expected, removing all but the initial site input field when the clear action is performed.