### PR TITLE
feat: Allow .json file uploads for transmission files

### DIFF
--- a/index.html
+++ b/index.html
@@ -322,7 +322,7 @@
 
                 <div class="flex px-4 py-3">
                   <!-- ID changed -->
-                  <input type="file" id="uploadEncryptedKeysInput" style="display: none;" accept=".nCodeKeys"/>
+                  <input type="file" id="uploadEncryptedKeysInput" style="display: none;" accept=".nCodeKeys,.json"/>
                   <button onclick="document.getElementById('uploadEncryptedKeysInput').click();" class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded h-10 px-4 bg-[#2e3928] text-white text-sm font-bold leading-normal tracking-[0.015em] flex-1">
                     <span class="truncate">Upload Encrypted Key Pair (.nCodeKeys)</span>
                   </button>
@@ -411,7 +411,7 @@
 
                 <div class="flex px-4 py-3">
                   <!-- ID changed -->
-                  <input type="file" id="dcodeFileInput" style="display: none;" accept=".nCodeTransmission"/>
+                  <input type="file" id="dcodeFileInput" style="display: none;" accept=".nCodeTransmission,.json"/>
                   <button onclick="document.getElementById('dcodeFileInput').click();" class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded h-10 px-4 bg-[#2e3928] text-white text-sm font-bold leading-normal tracking-[0.015em] flex-1">
                     <span class="truncate">Upload .nCodeTransmission File</span>
                   </button>

--- a/scripts/transmission.js
+++ b/scripts/transmission.js
@@ -201,8 +201,8 @@ async function decryptTransmission(event) {
         return;
     }
 
-    if (!file.name.endsWith('.nCodeTransmission')) {
-        showToast("Invalid file type. Please select a '.nCodeTransmission' file.");
+    if (!(file.name.endsWith('.nCodeTransmission') || file.name.endsWith('.json'))) {
+        showToast("Invalid file type. Please select a '.nCodeTransmission' or '.json' file.");
         event.target.value = null; // Clear the file input
         return;
     }
@@ -505,8 +505,8 @@ function handleUploadEncryptedKeys(event) {
         return;
     }
 
-    if (!file.name.endsWith('.nCodeKeys')) {
-        showToast("Please select a valid '.nCodeKeys' file.");
+    if (!(file.name.endsWith('.nCodeKeys') || file.name.endsWith('.json'))) {
+        showToast("Please select a valid '.nCodeKeys' or '.json' file.");
         event.target.value = null; // Clear the file input
         uploadedKeyFileData = null;
         return;


### PR DESCRIPTION
I've modified the file upload handling in the transmission tab to accept .json files in addition to the original .nCodeKeys and .nCodeTransmission extensions.

This addresses an issue where mobile browsers would sometimes rename downloaded key or transmission files to .json, preventing you from uploading them.

Changes:
- Updated `scripts/transmission.js`:
  - `handleUploadEncryptedKeys` now accepts `.nCodeKeys` or `.json`.
  - `decryptTransmission` now accepts `.nCodeTransmission` or `.json`.
  - Toast messages updated to reflect the new accepted file types.
- Updated `index.html`:
  - The `accept` attribute for `uploadEncryptedKeysInput` changed to `.nCodeKeys,.json`.
  - The `accept` attribute for `dcodeFileInput` changed to `.nCodeTransmission,.json`.

Download functionality remains unchanged; files are still downloaded with their original `.nCodeKeys` or `.nCodeTransmission` extensions.