### PR TITLE
Fix: Adjust nav bar padding and gap for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
             <h1 class="text-white text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 text-center pb-3 pt-5">nCode</h1>
             <p class="text-white text-base font-normal leading-normal pb-3 pt-1 px-4 text-center">Client-side encryption by Demicube.</p>
             <div class="pb-3">
-              <div class="flex border-b border-[#43543b] px-4 gap-8">
+            <div class="flex border-b border-[#43543b] px-2 gap-4 md:px-4 md:gap-8">
                 <a class="flex flex-col items-center justify-center border-b-[3px] border-b-white text-white pb-[13px] pt-4" href="javascript:void(0);" onclick="showContent('stringEncryptionContent', this)">
                   <p class="text-white text-sm font-bold leading-normal tracking-[0.015em]">String Encryption</p>
                 </a>


### PR DESCRIPTION
The navigation bar was overflowing on mobile screens, cutting off the right-most tab ("Transmission Encryption").

This commit adjusts the Tailwind CSS classes for the navigation bar container in `index.html`:
- Reduces horizontal padding from `px-4` to `px-2` on small screens.
- Reduces the gap between navigation items from `gap-8` to `gap-4` on small screens.
- Keeps the original `px-4` and `gap-8` for medium screens and above (`md:` prefix).

These changes ensure the navigation bar fits within the viewport on smaller devices while maintaining the original layout on larger screens.